### PR TITLE
Add tags to new post

### DIFF
--- a/src/components/posts/PostForm.js
+++ b/src/components/posts/PostForm.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getCategories } from "../../managers/categories";
-import { useParams } from "react-router-dom";
+import { getTags, postTagRelationships } from "../../managers/TagManager";
 
 
 export const PostForm = ({ token }) => {
@@ -11,6 +11,11 @@ export const PostForm = ({ token }) => {
     */
     const [categories, setCategories] = useState([]);
     const [formError, setFormError] = useState(false);
+
+    // Default state for all tags to list on form
+    const [tagList, setTagList] = useState([])
+    // Track state for tags being added to post
+    const [tagsOnPost, updateTagsOnPost] = useState([])
 
 
     const [post, update] = useState({
@@ -29,6 +34,14 @@ export const PostForm = ({ token }) => {
                 setCategories(categoryList);
             });
     }, []);
+
+    useEffect(
+        () => {
+            getTags()
+                .then(tagData => setTagList(tagData))
+        },
+        []
+    )
 
     const navigate = useNavigate();
 
@@ -58,9 +71,39 @@ export const PostForm = ({ token }) => {
             .then(response => response.json())
             .then((data) => {
                 const createdPostId = data.id
-                navigate(`/posts/${createdPostId}`);
+                console.log("New Post", data)
+                // If tags were selected, create the post/tag relationships with the new post id
+                if (tagsOnPost.length > 0) {
+                    postTagRelationships(createdPostId, tagsOnPost)
+                        .then((postedTags) => {
+                            console.log("New tags on post", postedTags)
+                            navigate(`/posts/${createdPostId}`)
+                        })
+                } else {
+                    navigate(`/posts/${createdPostId}`);
+                }
             });
     };
+
+    const addOrRemoveTag = (e) => {
+        const checkedTagId = parseInt(e.target.value)
+        console.log("checkedTagId", checkedTagId)
+        if (tagsOnPost.includes(checkedTagId)) {
+            const updatedTags = tagsOnPost.filter(tagId => tagId !== checkedTagId)
+            updateTagsOnPost(updatedTags)
+        } else {
+            const copy = [ ...tagsOnPost ]
+            copy.push(checkedTagId)
+            updateTagsOnPost(copy)
+        }
+    }
+    useEffect(
+        () => {
+            const post_body = ["num", tagsOnPost]
+            console.log(post_body)
+        },
+        [tagsOnPost]
+    )
 
     return (
         <form className="postForm">
@@ -139,6 +182,28 @@ export const PostForm = ({ token }) => {
                         }}
                     />
                 </div>
+            </fieldset>
+
+            <fieldset>
+                <h3 className="is-size-5 has-text-weight-bold mt-3">Add Tags to Your Post</h3>
+                <section className="py-2 px-4">
+                {
+                    tagList.length > 0 &&
+                    tagList.map((tag) => {
+                        return <div key={`tagCheck--${tag.id}`}>
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    value={tag.id}
+                                    checked={tagsOnPost.includes(tag.id)}
+                                    onChange={(e) => addOrRemoveTag(e)}
+                                />
+                                {tag.label}
+                            </label>
+                        </div>
+                    })
+                }
+                </section>
             </fieldset>
 
             <button

--- a/src/managers/TagManager.js
+++ b/src/managers/TagManager.js
@@ -13,3 +13,16 @@ export const postTags = (newTag) => {
       body: JSON.stringify(newTag)
   }).then(res => res.json())
 }
+
+export const postTagRelationships = (postId, tagsToPost) => {
+  const postBody = [postId, tagsToPost]
+
+  return fetch("http://localhost:8088/post_tags", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json"
+    },
+    body: JSON.stringify(postBody)
+  }).then(res => res.json())
+}


### PR DESCRIPTION
## Changes Made

- Added checkboxes to select tags to add when creating new Post
- Tracked state of tags being added to post
- Retrieved new post id to create new postTags
- Added fetch call to handle adding multiple new tag relationships
- removed unused `useParams()` import

## What dev team should see
- A checkbox to add tags to new post
- If checked, tag is staged to be added to post in the `tagsOnPost` state
- if unchecked, tag is unstaged and will not be added
- Once submitted, a response with a 201 status code and the newly created tag relationships in the body (if any were selected)

### My branch
`add-tags-to-post`
